### PR TITLE
Finished backend domain rating implementation

### DIFF
--- a/backend/app/Http/Controllers/DomainController.php
+++ b/backend/app/Http/Controllers/DomainController.php
@@ -5,6 +5,8 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use Illuminate\Http\JsonResponse as HttpJSONResponse;
 
+use App\Models\Domain;
+
 /**
  * Controller class which handles all operations specific to Domain objects
  */
@@ -17,11 +19,16 @@ class DomainController extends Controller
      * @return HttpJSONResponse ({boolean is_certified, int likes})
      */
     public function getRating(Request $request) : HttpJSONResponse {
-        $domain = $request->input('domain', '');  
-
-        //  TODO: Implement rating retrieval
-
-        return response()->json($domain);
+        $domainName = $request->input('domain', '');  
+        $domain = NULL;
+        if(strlen($domainName) > 0) {
+            $domain = Domain::where('name', $domainName)->first();
+            if(is_null($domain)) {
+                return response()->json(['error' => 'Backend API returned error: Domain not found']);
+            }
+            return response()->json($domain);
+        }
+        return response()->json(['error' => 'Backend API returned error: Null input']);
     }
 
     /**
@@ -31,9 +38,15 @@ class DomainController extends Controller
      * @return void
      */
     public function rateDomain(Request $request) : void {
-        $domain = $request->input('domain', '');
+        $domainName = $request->input('domain', '');
         $like = $request->input('like', true);
 
-        //  TODO: Implement domain rating ability
+        if(strlen($domainName) > 0) {
+            if($like) {
+                $domain = Domain::where('name', $domainName)->increment('likes');
+            } else {
+                $domain = Domain::where('name', $domainName)->decrement('likes');
+            }
+        }
     }
 }

--- a/backend/database/factories/DomainFactory.php
+++ b/backend/database/factories/DomainFactory.php
@@ -23,7 +23,7 @@ class DomainFactory extends Factory
     {
         return [
             'name' => $this->faker->domainName(),
-            'is_certified' => false,
+            'is_certified' => 0,
             'likes' => 0,
         ];
     }
@@ -37,7 +37,7 @@ class DomainFactory extends Factory
     {
         return $this->state(function (array $attributes) {
             return [
-                'is_certified' => true,
+                'is_certified' => 1,
             ];
         });
     }

--- a/backend/tests/Unit/GetRatingTest.php
+++ b/backend/tests/Unit/GetRatingTest.php
@@ -65,8 +65,9 @@ class GetRatingTest extends TestCase
         $response = $this->json('GET','/domain', ['domain' => $newDomain->name]);
 
         $response->assertSuccessful()->assertJson(fn (AssertableJson $json) =>
-            $json->where('rating', $newDomain->likes)
+            $json->where('likes', $newDomain->likes)
                 ->where('is_certified', $newDomain->is_certified)
+                ->etc()
         );
     }
 
@@ -83,8 +84,9 @@ class GetRatingTest extends TestCase
         $response = $this->json('GET','/domain', ['domain' => $newDomain->name]);
 
         $response->assertSuccessful()->assertJson(fn (AssertableJson $json) =>
-            $json->where('rating', $newDomain->likes)
+            $json->where('likes', $newDomain->likes)
                 ->where('is_certified', $newDomain->is_certified)
+                ->etc()
         );
     }
 }


### PR DESCRIPTION
Backend Changes:
- Updated methods in DomainController to finish domain rating implementation
  - Implemented getRating to return full domain information instead of just the provided domain name
  - Implemented rateDomain to allow for rating a domain positively or negatively
- Fixed DomainFactory is_certified assignments to reflect the 0/1 database column instead of true/false
- Fixed incomplete tests (missing -etc()) in RateDomainTest
- GetRatingTest and GetDomainTest now pass
- Covers Issue NTS-85 on Jira